### PR TITLE
Fix Request Signing

### DIFF
--- a/src/TinEyeApi.php
+++ b/src/TinEyeApi.php
@@ -243,6 +243,9 @@ class TinEyeApi
         $boundary = "---------------------" . md5(mt_rand() . microtime());
         $contenttype_header = "multipart/form-data; boundary=$boundary";
 
+        //Lower case and urlencode file_name
+        $file_name = strtolower(rawurlencode($file_name));
+
         //Compose api string to sign
         $api_sig_raw = $this->api_private_key . "POST" . $contenttype_header . $file_name . $date . $nonce;
         $api_sig_raw .= $this->api_url . $method . "/" . $signature_options;

--- a/tests/TestTinEyeApiSearchData.php
+++ b/tests/TestTinEyeApiSearchData.php
@@ -28,6 +28,21 @@ class TestTinEyeApiSearchData extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test that the file name is url encoded and lower cased
+     */
+    public function testFileNameEncoded()
+    {
+        $tineyeapi = new TinEyeApi();
+        $file_name = "MeL ONca-t1.jpg";
+        $search_result = $tineyeapi->searchData(
+            fopen('tests/meloncat.jpg', 'r'),
+            $file_name
+        );
+        $this->assertTrue($search_result['code'] === 200);
+        $this->assertTrue(sizeof($search_result['results']['matches']) > 1);
+    }
+
+    /**
      * Test that an error is thrown when a request is made to a non existant tld
      */
     public function testConnectionException()


### PR DESCRIPTION
Filenames that were not lower case were not being correctly lower cased and url encoded causing file names with chars that required url encoding or capital letters to cause incorrect signatures